### PR TITLE
add risk parity loss function & risk budgeting allocator

### DIFF
--- a/deepdow/layers/__init__.py
+++ b/deepdow/layers/__init__.py
@@ -2,7 +2,8 @@
 
 from .collapse import (AttentionCollapse, AverageCollapse, ElementCollapse, ExponentialCollapse,
                        MaxCollapse, SumCollapse)
-from .allocate import (AnalyticalMarkowitz, NCO, NumericalMarkowitz, Resample, SoftmaxAllocator,
+from .allocate import (AnalyticalMarkowitz, NCO, NumericalMarkowitz,
+                       NumericalRiskBudgeting, Resample, SoftmaxAllocator,
                        SparsemaxAllocator, WeightNorm)
 from .misc import Cov2Corr, CovarianceMatrix, KMeans, MultiplyByConstant
 from .transform import Conv, RNN, Warp, Zoom
@@ -20,6 +21,7 @@ __all__ = ['AnalyticalMarkowitz',
            'MultiplyByConstant',
            'NCO',
            'NumericalMarkowitz',
+           'NumericalRiskBudgeting',
            'Resample',
            'RNN',
            'SoftmaxAllocator',

--- a/deepdow/layers/allocate.py
+++ b/deepdow/layers/allocate.py
@@ -545,3 +545,63 @@ class WeightNorm(torch.nn.Module):
         normalized = clamped / clamped.sum()
 
         return torch.stack(n_samples * [normalized], dim=0)
+
+
+class NumericalRiskBudgeting(nn.Module):
+    """Convex optimization layer stylized into portfolio optimization problem.
+
+    Parameters
+    ----------
+    n_assets : int
+        Number of assets.
+
+    Attributes
+    ----------
+    cvxpylayer : CvxpyLayer
+        Custom layer used by a third party package called cvxpylayers.
+
+    References
+    ----------
+    [1] https://github.com/cvxgrp/cvxpylayers
+    [2] https://poseidon01.ssrn.com/delivery.php?ID=390114006122099106072078096104069112056050065027039051078098000067064086112072124109005035107005061025044074073029126125070080038037078052000085104024102000110030090033033078083120080087081020021019107089002123119030075084115101026124093011116092064098&EXT=pdf
+    [3] https://mpra.ub.uni-muenchen.de/37749/2/MPRA_paper_37749.pdf
+    """
+    def __init__(self, n_assets, max_weight=1):
+        """Construct."""
+        super().__init__()
+        covmat_sqrt = cp.Parameter((n_assets, n_assets))
+        b = cp.Parameter(n_assets, nonneg=True)
+
+        w = cp.Variable(n_assets)
+        term_1 = 0.5 * cp.sum_squares(covmat_sqrt @ w)
+        # term_2 = cp.sum(b * cp.log(w)) # taking log(w) makes the problem non-dpp
+        # TODO: not sure how to make it dpp with log, refer Section 4.1: https://web.stanford.edu/~boyd/papers/pdf/diff_cvxpy.pdf
+        term_2 = cp.sum(cp.multiply(b, w))
+        objective = cp.Minimize(term_1 - term_2) # refer [2]
+        constraint = [cp.sum(w) == 1, cp.sum(b) == 1, w >= 0, w <= max_weight] # refer [2]
+
+        prob = cp.Problem(objective, constraint)
+
+        assert prob.is_dpp()
+
+        self.cvxpylayer = CvxpyLayer(prob, parameters=[covmat_sqrt, b], variables=[w])
+
+    def forward(self, covmat_sqrt, b):
+        """Perform forward pass.
+
+        Parameters
+        ----------
+        covmat : torch.Tensor
+            Of shape (n_samples, n_assets, n_assets) representing the covariance matrix.
+
+        b : torch.Tensor
+            Of shape (n_samples, n_assets) representing the budget, 
+            risk contribution from each component (asset) is equal to the budget, refer [3]
+
+        Returns
+        -------
+        weights : torch.Tensor
+            Of shape (n_samples, n_assets) representing the optimal weights as determined by the convex optimizer.
+
+        """
+        return self.cvxpylayer(covmat_sqrt, b)[0]

--- a/deepdow/layers/allocate.py
+++ b/deepdow/layers/allocate.py
@@ -563,9 +563,10 @@ class NumericalRiskBudgeting(nn.Module):
     References
     ----------
     [1] https://github.com/cvxgrp/cvxpylayers
-    [2] https://poseidon01.ssrn.com/delivery.php?ID=390114006122099106072078096104069112056050065027039051078098000067064086112072124109005035107005061025044074073029126125070080038037078052000085104024102000110030090033033078083120080087081020021019107089002123119030075084115101026124093011116092064098&EXT=pdf
+    [2] https://papers.ssrn.com/sol3/papers.cfm?abstract_id=2297383
     [3] https://mpra.ub.uni-muenchen.de/37749/2/MPRA_paper_37749.pdf
     """
+
     def __init__(self, n_assets, max_weight=1):
         """Construct."""
         super().__init__()
@@ -573,12 +574,12 @@ class NumericalRiskBudgeting(nn.Module):
         b = cp.Parameter(n_assets, nonneg=True)
 
         w = cp.Variable(n_assets)
+
         term_1 = 0.5 * cp.sum_squares(covmat_sqrt @ w)
-        # term_2 = cp.sum(b * cp.log(w)) # taking log(w) makes the problem non-dpp
-        # TODO: not sure how to make it dpp with log, refer Section 4.1: https://web.stanford.edu/~boyd/papers/pdf/diff_cvxpy.pdf
-        term_2 = cp.sum(cp.multiply(b, w))
-        objective = cp.Minimize(term_1 - term_2) # refer [2]
-        constraint = [cp.sum(w) == 1, cp.sum(b) == 1, w >= 0, w <= max_weight] # refer [2]
+        term_2 = b @ cp.log(w)
+
+        objective = cp.Minimize(term_1 - term_2)  # refer [2]
+        constraint = [cp.sum(w) == 1, w >= 0, w <= max_weight]  # refer [2]
 
         prob = cp.Problem(objective, constraint)
 
@@ -595,7 +596,7 @@ class NumericalRiskBudgeting(nn.Module):
             Of shape (n_samples, n_assets, n_assets) representing the covariance matrix.
 
         b : torch.Tensor
-            Of shape (n_samples, n_assets) representing the budget, 
+            Of shape (n_samples, n_assets) representing the budget,
             risk contribution from each component (asset) is equal to the budget, refer [3]
 
         Returns

--- a/deepdow/losses.py
+++ b/deepdow/losses.py
@@ -3,6 +3,7 @@
 All losses are designed for minimization.
 """
 from types import MethodType
+from .layers import CovarianceMatrix
 
 import torch
 
@@ -1038,3 +1039,73 @@ class WorstReturn(Loss):
                                                                                   self.returns_channel,
                                                                                   self.input_type,
                                                                                   self.output_type)
+
+
+class RiskParity(Loss):
+    """Risk Parity Portfolio.
+
+    source: EQN (4) of
+    https://poseidon01.ssrn.com/delivery.php?ID=390114006122099106072078096104069112056050065027039051078098000067064086112072124109005035107005061025044074073029126125070080038037078052000085104024102000110030090033033078083120080087081020021019107089002123119030075084115101026124093011116092064098&EXT=pdf
+    
+    Parameters
+    ----------
+    returns_channel : int
+        Which channel of the `y` target represents returns.
+
+    input_type : str, {'log', 'simple'}
+        What type of returns are we dealing with in `y`.
+
+    output_type : str, {'log', 'simple'}
+        What type of returns are we dealing with in the output.
+
+    eps : float
+        Additional constant to avoid log zero error.
+    """
+    
+    def __init__(self, returns_channel=0, input_type='log', output_type='simple', eps=1e-4):
+        self.returns_channel = returns_channel
+        self.covariance_layer = CovarianceMatrix(sqrt=False)
+        self.input_type = input_type
+        self.output_type = output_type
+        self.eps = eps
+        
+    def __call__(self, weights, y):
+        """.
+        Parameters
+        ----------
+        weights : torch.Tensor
+            Tensor of shape `(n_samples, n_assets)` representing the predicted weights by our portfolio optimizer.
+        y : torch.Tensor
+            Tensor of shape `(n_samples, n_channels, horizon, n_assets)` representing the evolution over the next
+            `horizon` timesteps.
+        Returns
+        -------
+         torch.Tensor
+            Tensor of shape `(n_samples,)` representing the per sample risk parity.
+        """
+        prets = portfolio_returns(weights,
+                                  y[:, self.returns_channel, ...],
+                                  input_type=self.input_type,
+                                  output_type=self.output_type) # (n_samples, horizon)
+        covar = self.covariance_layer(y[:, self.returns_channel, ...]) # (n_samples, n_assets, n_assets)
+        
+        b = 1/weights.shape[-1] # equally weighted budget, b, makes this formula a special case of risk budgeting called risk parity
+        
+        # ensure non-zero weights
+        weights = torch.where(weights==0.0, weights+self.eps, weights)
+        # add dimension for matmul operation
+        weights = weights.unsqueeze(dim=1)
+        
+        term_1 = 0.5*torch.matmul(weights, torch.matmul(covar, weights.permute((0,2,1))))
+        term_2 = torch.sum(b*torch.log(weights.permute((0,2,1))), dim=1).unsqueeze(dim=-1)
+        rp = (term_1 - term_2).squeeze()
+
+        return rp
+        
+    def __repr__(self):
+        """Generate representation string."""
+        return "{}(returns_channel={}, input_type='{}', output_type='{}', eps={})".format(self.__class__.__name__,
+                                                                                          self.returns_channel,
+                                                                                          self.input_type,
+                                                                                          self.output_type, 
+                                                                                          self.eps)

--- a/docs/source/layers.rst
+++ b/docs/source/layers.rst
@@ -266,6 +266,32 @@ tensors (batched along the sample dimension):
 
     The major downside of using this allocator is a significant decrease in speed.
 
+NumericalRiskBudgeting
+**********************
+Proposed in [Spinu2013]_.
+
+.. math::
+
+    \begin{aligned}
+    \min_{\textbf{w}} \quad & \frac{1}{2}{\textbf{w}}^{T}  \boldsymbol{\Sigma} \textbf{w} - \sum_{i=1}^{N} b_i  \log(w_i) \\
+    \textrm{s.t.} \quad & \sum_{i=1}^{N}w_i = 1 \\
+    \quad & w_i >= 0, i \in \{1,...,N\}\\
+    \quad & w_i <= w_{\text{max}}, i \in \{1,...,N\}\\
+    \end{aligned}
+
+where the :math:`b_i, i=1,..,N` are the risk budgets. The user needs to provide
+:code:`n_assets` (:math:`N` in the above formulation) and :code:`max_weight`
+(:math:`w_{\text{max}}`) when constructing this layer. To perform a forward pass one passes the following
+tensors (batched along the sample dimension):
+
+- :code:`covmat_sqrt` - Corresponds to a (matrix) square root of the covariance matrix :math:`\boldsymbol{\Sigma}`
+- :code:`b` - Risk budgets
+
+
+.. warning::
+
+    The major downside of using this allocator is a significant decrease in speed.
+
 Resample
 ********
 The :code:`Resample` layer is inspired by [Michaud2007]_. It is a **metallocator** that expects an instance
@@ -493,6 +519,9 @@ References
 
 .. [Prado2019]
    Lopez de Prado, M. (2019). A Robust Estimator of the Efficient Frontier. Available at SSRN 3469961.
+
+.. [Spinu2013]
+   Spinu, Florin, An Algorithm for Computing Risk Parity Weights (July 30, 2013). Available at SSRN: https://ssrn.com/abstract=2297383 or http://dx.doi.org/10.2139/ssrn.2297383
 
 .. [Jiang2017]
    Jiang, Zhengyao, and Jinjun Liang. "Cryptocurrency portfolio management with deep reinforcement learning." 2017 Intelligent Systems Conference (IntelliSys). IEEE, 2017

--- a/docs/source/losses.rst
+++ b/docs/source/losses.rst
@@ -168,6 +168,16 @@ The **negative** of mean portfolio returns over the :code:`horizon` time steps.
 
     {\mu}^{\textbf{w}} = \frac{\sum_{i}^{\text{horizon}} r^{\textbf{w}}_{i} }{\text{horizon}}
 
+RiskParity
+**********
+
+.. math::
+
+   \sum_{i=1}^{N}\Big(\frac{\sigma}{N} - w_i \big(\frac{\Sigma\textbf{w}}{\sigma}\big)_i\Big) ^ 2
+
+where :math:`\sigma=\sqrt{\textbf{w}^T\Sigma\textbf{w}}` and :math:`\Sigma` is
+the covariance matrix of asset returns.
+
 Quantile (Value at Risk)
 ************************
 The **negative** of the :code:`p`-quantile of portfolio returns. Note that in the background it solved via

--- a/tests/test_layers.py
+++ b/tests/test_layers.py
@@ -4,7 +4,8 @@ import torch
 from deepdow.layers import (AverageCollapse, AttentionCollapse, ElementCollapse,
                             ExponentialCollapse, MaxCollapse,
                             SumCollapse)
-from deepdow.layers import (AnalyticalMarkowitz, NCO, NumericalMarkowitz, Resample,
+from deepdow.layers import (AnalyticalMarkowitz, NCO, NumericalMarkowitz,
+                            NumericalRiskBudgeting, Resample,
                             SoftmaxAllocator, SparsemaxAllocator, WeightNorm)
 from deepdow.layers import Cov2Corr, CovarianceMatrix, KMeans, MultiplyByConstant
 from deepdow.layers import Conv, RNN, Warp, Zoom
@@ -326,6 +327,9 @@ class TestNumericalMarkowitz:
         weights = popt(rets, covmat_sqrt, gamma, alpha)
 
         assert weights.shape == (n_samples, n_assets)
+        assert torch.allclose(weights.sum(dim=-1), torch.ones(n_samples,
+                                                              device=device,
+                                                              dtype=dtype))
         assert weights.dtype == X.dtype
         assert weights.device == X.device
 
@@ -777,3 +781,30 @@ class TestZoom:
         x_warped = layer_warp(X, tform)
 
         assert torch.allclose(x_zoomed, x_warped)
+
+
+class TestNumericalRiskBudgeting:
+    def test_basic(self, Xy_dummy):
+        X, _, _, _ = Xy_dummy
+        device, dtype = X.device, X.dtype
+        n_samples, n_channels, lookback, n_assets = X.shape
+
+        popt = NumericalRiskBudgeting(n_assets)
+
+        covmat_sqrt__ = torch.rand((n_assets, n_assets)).to(device=X.device, dtype=X.dtype)
+        covmat_sqrt_ = covmat_sqrt__ @ covmat_sqrt__
+        covmat_sqrt_.add_(torch.eye(n_assets, dtype=dtype, device=device))
+
+        covmat_sqrt = torch.stack(n_samples * [covmat_sqrt_])
+
+        budgets = torch.rand((n_samples, n_assets), dtype=dtype, device=device)
+        budgets /= budgets.sum(dim=-1, keepdim=True)
+
+        weights = popt(covmat_sqrt, budgets)
+
+        assert weights.shape == (n_samples, n_assets)
+        assert torch.allclose(weights.sum(dim=-1), torch.ones(n_samples,
+                                                              device=device,
+                                                              dtype=dtype))
+        assert weights.dtype == X.dtype
+        assert weights.device == X.device


### PR DESCRIPTION
added risk parity loss function based on [this paper](https://poseidon01.ssrn.com/delivery.php?ID=390114006122099106072078096104069112056050065027039051078098000067064086112072124109005035107005061025044074073029126125070080038037078052000085104024102000110030090033033078083120080087081020021019107089002123119030075084115101026124093011116092064098&EXT=pdf), here is a [stack exchange version, Ze Vinicius's answer](https://quant.stackexchange.com/questions/3114/how-to-construct-a-risk-parity-portfolio) to make things simple. Please double check by formulas. Thanks.