### PR TITLE
Fix readthedocs builds

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,8 +13,6 @@ python:
   version: 3.7
   install:
     - method: pip
-      path: numpy==1.19.4
-    - method: pip
       path: .
       extra_requirements:
       - examples

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -13,6 +13,8 @@ python:
   version: 3.7
   install:
     - method: pip
+      path: numpy==1.19.4
+    - method: pip
       path: .
       extra_requirements:
       - examples

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,10 +7,14 @@ version: 2
 sphinx:
   configuration: docs/conf.py
 
+build:
+    image: stable
+
 
 # Optionally set the version of Python and requirements required to build your docs
 python:
   version: 3.7
+  system_packages: true
   install:
     - method: pip
       path: .

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     extras_require={
         "dev": ["codecov", "flake8==3.7.9", "pydocstyle", "pytest>=4.6", "pytest-cov", "tox"],
         "docs": ["sphinx", "sphinx_rtd_theme"],
-        "examples": ["numpy==1.19.2", "sphinx_gallery", "statsmodels"]
+        "examples": ["sphinx_gallery", "statsmodels"]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     extras_require={
         "dev": ["codecov", "flake8==3.7.9", "pydocstyle", "pytest>=4.6", "pytest-cov", "tox"],
         "docs": ["sphinx", "sphinx_rtd_theme"],
-        "examples": ["numpy==1.19.3", "sphinx_gallery", "statsmodels"]
+        "examples": ["numpy==1.19.2", "sphinx_gallery", "statsmodels"]
     }
 )

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,6 @@ setup(
     extras_require={
         "dev": ["codecov", "flake8==3.7.9", "pydocstyle", "pytest>=4.6", "pytest-cov", "tox"],
         "docs": ["sphinx", "sphinx_rtd_theme"],
-        "examples": ["sphinx_gallery", "statsmodels"]
+        "examples": ["numpy==1.19.3", "sphinx_gallery", "statsmodels"]
     }
 )


### PR DESCRIPTION
Since trying to install `numpy` from a wheel leads to a broken installation, this PR suggests using a system `numpy`.
RTD is installing `numpy` and other scientific packages inside of their docker image to serve exactly this purpose - there is no need to compile complicated packages from scratch or hope the wheels are valid for the platform.

Probably will break again in the future, but good for now.

See also
* https://hub.docker.com/r/readthedocs/build/dockerfile
* https://docs.readthedocs.io/en/stable/config-file/v2.html?highlight=numpy#python-system-packages

